### PR TITLE
Puppeteer docs - fixed typo + some minor text changes

### DIFF
--- a/src/tools/Puppeteer/readme.md
+++ b/src/tools/Puppeteer/readme.md
@@ -1,5 +1,5 @@
 `<Puppeteer/>` and it's accompanying components/HOCs allow you to override the props of descendants
-who are decorated in the `puppet()` HOC. This is useful in cases where you want components to 
+who are decorated in the `puppet()` HOC. This is useful in cases where you want components to
 have different behaviors when they are nested in certain containers, or when you want to add
 logic to a component on a higher abstraction layer.
 
@@ -12,14 +12,11 @@ message based on some validation function:
 const TextInput = ({value, onChange, validation}) => {
     const [error, setError] = useState(false);
     const handleOnChange = useCallback(e => {
-        const value = e.target.value;
-        if (!validation(value)) {
-            setError(true);
-        } else {
-            setError(false);
-        }
+        const {value} = e.target;
+        setError(!validation(value));
         onChange(value);
     }, [onChange, validation, setError]);
+
     return (
         <>
             <input type='text' value={value} onChange={handleOnChange}/>
@@ -30,29 +27,27 @@ const TextInput = ({value, onChange, validation}) => {
 ```
 
 So far so good, but now you want to have another input, `NumberInput`, which is also validatable.
-Instead of having the same code duplicated in multiple places, we need to share it. There are multiple
-ways of doing that - using a hook, using a HOC, or just having a utility function used by both.
+Instead of having the same code duplicated in multiple places, we need to share it.
+There are multiple ways of doing so: using a *hook*, using a *HOC*, or just having a utility function used by both.
+
 `<Puppeteer/>` offers another way, one in which the logic is lifted up to a higher abstraction
-layer, completely removing the logic from the receiving component. From a SOLID point of view,
-this component has already got too many responsibilities so even if you didn't need to share this 
-logic, it makes sense to move it to another component to make it more readable and less likely to change.
+layer, completely removing the logic from the receiving component. From a [SOLID](https://en.wikipedia.org/wiki/SOLID) point of view,
+this component already has too many responsibilities so even if you didn't need to share the above
+logic, it makes sense moving it to another component, making both more readable and less likely to change.
 
 To do that, we need to create another component, in which we will use `<Puppeteer/>` to control
-the props of the descending `pupper()` wrapped component. All the validation logic will move to that
+the props of the descending `puppet()` wrapped component. All the validation logic will move to that
 component, leaving the original `TextInput` clean of any validation responsibilities:
 
 ```jsx
 const Validation = ({children, validation}) => {
     const [error, setError] = useState(false);
+
     return (
         <Puppeteer props={{
             onChange: props => value => {
                 props.onChange(value); // Call the original prop
-                if (!validation(value)) {
-                    setError(true);
-                } else {
-                    setError(false);
-                }
+                setError(!validation(value));
             }
         }}>
             {children}
@@ -65,6 +60,7 @@ const TextInput = puppet(({value, onChange}) => {
     const handleOnChange = useCallback(e => {
         onChange(e.target.value);
     }, [onChange]);
+
     return (
         <input type='text' value={value} onChange={handleOnChange}/>
     );


### PR DESCRIPTION
- Typo *"Pupper"* instead of *"Puppet"* 
- simplified code examples validation logic the make it easier to follow the code (less lines)