### PR TITLE
[collapsible] - fixes #57 - nested collapsibles sharing the same "expanded" prop aren't collapsing as expected

### DIFF
--- a/src/components/Collapsible/Collapsible.jsx
+++ b/src/components/Collapsible/Collapsible.jsx
@@ -27,7 +27,7 @@ export const Collapsible = ({expanded, children, onTransitionEnd, ...props}) => 
     const handleOnTransitionEnd = useCallback(e => {
         // 'transform' is the longest transition property out of multiple ones
         if (e.propertyName === 'transform') {
-            setState(state => ({...state, motion: '', height: state.height ? 'auto' : '0'}));
+            setState(state => ({...state, motion: '', height: state.height ? 'auto' : 0}));
             onTransitionEnd(e);
         }
     }, [onTransitionEnd]);


### PR DESCRIPTION
`setState` in `handleOnTransitionEnd` callback had different type for the `0` value of `height` then the other types used. It must be kept type `Number`.

The `motion` *useEffect* sets the `height` to `0` (Number) and so React must not thing the height was changed from `0` to `"0"` (Number -> String) and then trigger a DOM change (which shouldn't happen).

[Demo](https://codesandbox.io/s/webrix-collapsible-kmb3t?file=/src/index.js)