### PR TITLE
fix: Element is undefined in SSR

### DIFF
--- a/src/hooks/useBoundingRectObserver/useBoundingRectObserver.js
+++ b/src/hooks/useBoundingRectObserver/useBoundingRectObserver.js
@@ -21,6 +21,9 @@ import useAnimationFrame from 'hooks/useAnimationFrame';
 
 export const getBoundingRects = refs => (
     refs.map(ref => {
+        if (typeof window === 'undefined') {
+            return undefined;
+        }
         if (ref.current) {
             return ref.current.getBoundingClientRect();
         }


### PR DESCRIPTION
Problem: Try to render Poppable component with Nextjs in SSR enviroment leads to error: "Element is undefined" since we are in nodejs enviroment. We need return before, if we are in nodejs context. 

-> fix: Element is undefined in SSR - update getBoundingRects



