### PR TITLE
Scrollable - stop propagation on click thumb

### DIFF
--- a/src/components/Scrollable/components/HorizontalScrollbar/HorizontalScrollbar.jsx
+++ b/src/components/Scrollable/components/HorizontalScrollbar/HorizontalScrollbar.jsx
@@ -27,6 +27,7 @@ const HorizontalScrollbar = () => {
     const props = Movable.useMove(useMemo(() => [move(container, thumb, track)], [container]));
 
     const handleOnClick = e => {
+        e.stopPropagation();
         // Ignore clicks on the thumb itself
         if (!thumb.current.contains(e.target)) {
             const {left, width} = track.current.getBoundingClientRect();

--- a/src/components/Scrollable/components/HorizontalScrollbar/HorizontalScrollbar.test.js
+++ b/src/components/Scrollable/components/HorizontalScrollbar/HorizontalScrollbar.test.js
@@ -22,10 +22,10 @@ describe('<HorizontalScrollbar/>', () => {
             rewire.__Rewire__('useContext', () => ({container}));
             const wrapper = shallow(<HorizontalScrollbar/>);
 
-            wrapper.find('.scrollbar-track').prop('onClick')({clientX: 0});
+            wrapper.find('.scrollbar-track').prop('onClick')({clientX: 0, stopPropagation: noop});
             expect(container.current.scrollLeft).toEqual(0);
 
-            wrapper.find('.scrollbar-track').prop('onClick')({clientX: 50});
+            wrapper.find('.scrollbar-track').prop('onClick')({clientX: 50, stopPropagation: noop});
             expect(container.current.scrollLeft).toEqual(100);
 
             rewire.__ResetDependency__('useRef');

--- a/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.jsx
+++ b/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.jsx
@@ -27,7 +27,7 @@ const VerticalScrollbar = () => {
     const props = Movable.useMove(useMemo(() => [move(container, thumb, track)], [container]));
 
     const handleOnClick = e => {
-        e.stopPropagation();
+        e?.stopPropagation();
         // Ignore clicks on the thumb itself
         if (!thumb.current.contains(e.target)) {
             const {top, height} = track.current.getBoundingClientRect();

--- a/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.jsx
+++ b/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.jsx
@@ -27,6 +27,7 @@ const VerticalScrollbar = () => {
     const props = Movable.useMove(useMemo(() => [move(container, thumb, track)], [container]));
 
     const handleOnClick = e => {
+        e.stopPropagation();
         // Ignore clicks on the thumb itself
         if (!thumb.current.contains(e.target)) {
             const {top, height} = track.current.getBoundingClientRect();

--- a/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.jsx
+++ b/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.jsx
@@ -27,7 +27,7 @@ const VerticalScrollbar = () => {
     const props = Movable.useMove(useMemo(() => [move(container, thumb, track)], [container]));
 
     const handleOnClick = e => {
-        e?.stopPropagation();
+        e.stopPropagation();
         // Ignore clicks on the thumb itself
         if (!thumb.current.contains(e.target)) {
             const {top, height} = track.current.getBoundingClientRect();

--- a/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.test.js
+++ b/src/components/Scrollable/components/VerticalScrollbar/VerticalScrollbar.test.js
@@ -22,10 +22,10 @@ describe('<VerticalScrollbar/>', () => {
             rewire.__Rewire__('useContext', () => ({container}));
             const wrapper = shallow(<VerticalScrollbar/>);
 
-            wrapper.find('.scrollbar-track').prop('onClick')({clientY: 0});
+            wrapper.find('.scrollbar-track').prop('onClick')({clientY: 0, stopPropagation: noop});
             expect(container.current.scrollTop).toEqual(0);
 
-            wrapper.find('.scrollbar-track').prop('onClick')({clientY: 50});
+            wrapper.find('.scrollbar-track').prop('onClick')({clientY: 50, stopPropagation: noop});
             expect(container.current.scrollTop).toEqual(100);
 
             rewire.__ResetDependency__('useRef');


### PR DESCRIPTION
The issue is in our DropDown, it has Poppable and Scrollable inside. The behavior we have is on clicking on Poppable it closes the component, so if we need to keep it opened we use stopPropagation for example list of checkboxes, regarding Scrollable it works well if to use mouse wheel, but on dragging Thumb by mouse button it makes click inside of Poppable and closes the component.