### PR TITLE
fix(#77): Removed useUnmounted hook and cleanup of useMounted

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,7 +2,7 @@ export {default as useAnimationFrame} from './useAnimationFrame';
 export {default as useBooleanState, useVisibilityState, useFocusabilityState} from './useBooleanState';
 export {default as useBoundingRectObserver} from './useBoundingRectObserver';
 export {default as useClickOutside, ClickOutside, ClickOutsideOverride} from './useClickOutside';
-export {default as useMounted, useUnmounted} from './useMounted';
+export {default as useMounted} from './useMounted';
 export {default as useDebounce} from './useDebounce';
 export {default as useDimensions} from './useDimensions';
 export {default as useEventListener} from './useEventListener';

--- a/src/hooks/useMounted/index.js
+++ b/src/hooks/useMounted/index.js
@@ -15,5 +15,4 @@
  */
 
 import {useMounted} from './useMounted';
-export {useUnmounted} from './useMounted';
 export default useMounted;

--- a/src/hooks/useMounted/useMounted.js
+++ b/src/hooks/useMounted/useMounted.js
@@ -20,13 +20,6 @@ export const useMounted = () => {
     const mounted = useRef(false);
     useEffect(() => {
         mounted.current = true;
-        return () => mounted.current = false;
     }, []);
     return mounted.current;
-};
-
-export const useUnmounted = () => {
-    const unmounted = useRef(false);
-    useEffect(() => () => {unmounted.current = true}, []);
-    return unmounted.current;
 };

--- a/src/hooks/useMounted/useMounted.test.js
+++ b/src/hooks/useMounted/useMounted.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {mount} from 'enzyme';
-import {useMounted, useUnmounted} from './useMounted';
+import {useMounted} from './useMounted';
 
 describe('useMounted()', () => {
     it('Should return the previous value', () => {
@@ -15,24 +15,6 @@ describe('useMounted()', () => {
         act(() => {wrapper = mount(<Elem/>)});
         expect(wrapper.find('.unmounted').length).toEqual(1);
         expect(wrapper.find('.mounted').length).toEqual(0);
-        wrapper.setProps({foo: 'bar'}); // Force an update...
-        expect(wrapper.find('.mounted').length).toEqual(1);
-        expect(wrapper.find('.unmounted').length).toEqual(0);
-    });
-});
-
-describe('useUnmounted()', () => {
-    it('Should return the previous value', () => {
-        const Elem = () => {
-            const unmounted = useUnmounted();
-            return (
-                <div className={`${unmounted ? 'un' : ''}mounted`}/>
-            );
-        };
-        let wrapper = null;
-        act(() => {wrapper = mount(<Elem/>)});
-        expect(wrapper.find('.unmounted').length).toEqual(0);
-        expect(wrapper.find('.mounted').length).toEqual(1);
         wrapper.setProps({foo: 'bar'}); // Force an update...
         expect(wrapper.find('.mounted').length).toEqual(1);
         expect(wrapper.find('.unmounted').length).toEqual(0);


### PR DESCRIPTION
The `useUnmounted` hook does not work. Here's why:
When the cleanup function of the `useEffect` runs, and the value of the reference is being changed to `true`, it doesn't actually reflect to the component using the hook. The reason for this is that the return statement of the hook is not being called after the unmount.
This hook should be implemented anew for each use case, and can not be implemented as a custom hook.
For the same reason, removed cleanup function in `useEffect` of `useMounted`.