### PR TITLE
pref(#6) - Remove Branding Styles

### DIFF
--- a/src/components/Scrollable/Scrollable.scss
+++ b/src/components/Scrollable/Scrollable.scss
@@ -2,16 +2,12 @@
   --scrollable-track-thickness: 12px;
   --scrollable-thumb-thickness: Calc(var(--scrollable-track-thickness)/2);
   --scrollable-thumb-offset: 3px;
+  --scrollable-thumb-color: silver;
 
   position: relative;
   max-height: 100%;
   max-width: 100%;
   display: flex;
-
-  &:hover > .scrollbar-track .scrollbar-thumb .scrollbar-thumb-inner {
-    opacity: 1;
-    transition-delay: 0s;
-  }
 
   .scrollbar-inner {
     position: relative;
@@ -37,10 +33,7 @@
       cursor: pointer;
 
       .scrollbar-thumb-inner {
-        background-color: rgba(28, 34, 43, 0.6);
-        border-radius: 4px;
-        opacity: 0;
-        transition: opacity 0.2s ease-out 0.5s; // The transition delay is used to keep the thumb visible for a short time when the cursor leaves. (see `Scrollable.constants.js`)
+        background-color: var(--scrollable-thumb-color);
       }
     }
   }


### PR DESCRIPTION
The styles that were removed:

```
.scrollbar {
  &:hover > .scrollbar-track .scrollbar-thumb .scrollbar-thumb-inner {
    opacity: 1;
    transition-delay: 0s;
  }

  .scrollbar-track .scrollbar-thumb .scrollbar-thumb-inner {
    border-radius: 4px;
    opacity: 0;
    transition: opacity 0.2s ease-out 0.5s; // The transition delay is used to keep the thumb visible for a short time when the cursor leaves. (see `Scrollable.constants.js`)
  }
}
```