### PR TITLE
Collapsible DOM updates

### DIFF
--- a/src/components/Collapsible/Collapsible.jsx
+++ b/src/components/Collapsible/Collapsible.jsx
@@ -19,6 +19,8 @@ import classNames from 'classnames';
 import {propTypes, defaultProps} from './Collapsible.props';
 import './Collapsible.scss';
 
+export const NAMESPACE = 'collapsible';
+
 export const Collapsible = ({expanded, children, onTransitionEnd, ...props}) => {
     const [{motion, height}, setState] = useState({motion: '', height: expanded ? 'auto' : 0});
     const hasChildren = !!React.Children.count(children);
@@ -50,16 +52,18 @@ export const Collapsible = ({expanded, children, onTransitionEnd, ...props}) => 
             setState(state => ({...state, height: 0}))
     }, [motion]);
 
+    const className = classNames(
+        NAMESPACE, // base namespace selector
+        {
+            [`${NAMESPACE}--${motion}`]: motion, // temporary state for transitions (BEM modifier name)
+            [`${NAMESPACE}--expanded`]: expanded && !motion,
+        },
+        props.className
+    );
+
     return (
-        <div {...props} className={classNames('collapsible', motion, {expanded: expanded && !motion}, props.className)}>
-            {hasChildren && (
-                <div
-                    className='content-wrapper'
-                    onTransitionEnd={handleOnTransitionEnd}
-                    style={{height}}>
-                    <div className='content' ref={contentRef}>{children}</div>
-                </div>
-            )}
+        <div {...props} className={className} style={{...props.style, height}} onTransitionEnd={handleOnTransitionEnd}>
+            {hasChildren && <div className={`${NAMESPACE}__content`} ref={contentRef}>{children}</div>}
         </div>
     );
 };

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -3,22 +3,16 @@
   --delay: calc(var(--duration) * .5);
   --expanded: initial;
 
-  // display: flex;
-  // flex-direction: column;
-  // justify-content: center;
-  // overflow: hidden;
+  transition:
+    height    calc(var(--duration) * .75) cubic-bezier(.7, 0, .3, 1) calc(var(--delay) * (var(--expanded, 2) - 1)),
+    opacity   calc(var(--duration) * .5)  ease-out                   calc(var(--delay) * var(--expanded, 0)),
+    transform calc(var(--duration) * 1)   ease-out;
+  overflow: hidden;
+  opacity: var(--expanded, 0);
+  transform: var(--expanded, translateX(-40px)); // Slide from left
 
-  // > .content-wrapper {
-    transition:
-      height    calc(var(--duration) * .75) cubic-bezier(.7, 0, .3, 1) calc(var(--delay) * (var(--expanded, 2) - 1)),
-      opacity   calc(var(--duration) * .5)  ease-out                   calc(var(--delay) * var(--expanded, 0)),
-      transform calc(var(--duration) * 1)   ease-out;
-    overflow: hidden;
-    opacity: var(--expanded, 0);
-    transform: var(--expanded, translateX(-40px)); // Slide from left
-  // }
-
-  &--expanded, &--expanding {
+  &--expanded,
+  &--expanding {
     --expanded: 1;
   }
 }

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -2,11 +2,12 @@
   --duration: 300ms;
   --delay: calc(var(--duration) * .5);
   --expanded: initial;
+  --easing: cubic-bezier(.7, 0, .3, 1);
 
   transition:
-    height    calc(var(--duration) * .75) cubic-bezier(.7, 0, .3, 1) calc(var(--delay) * (var(--expanded, 2) - 1)),
-    opacity   calc(var(--duration) * .5)  ease-out                   calc(var(--delay) * var(--expanded, 0)),
-    transform calc(var(--duration) * 1)   ease-out;
+    height calc(var(--duration) * .75) var(--easing) calc(var(--delay) * (var(--expanded, 2) - 1)),
+    opacity calc(var(--duration) * .5) ease-out calc(var(--delay) * var(--expanded, 0)),
+    transform calc(var(--duration) * 1) ease-out;
   overflow: hidden;
   opacity: var(--expanded, 0);
   transform: var(--expanded, translateX(-40px)); // Slide from left

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -3,12 +3,12 @@
   --delay: calc(var(--duration) * .5);
   --expanded: initial;
 
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  overflow: hidden;
+  // display: flex;
+  // flex-direction: column;
+  // justify-content: center;
+  // overflow: hidden;
 
-  > .content-wrapper {
+  // > .content-wrapper {
     transition:
       height    calc(var(--duration) * .75) cubic-bezier(.7, 0, .3, 1) calc(var(--delay) * (var(--expanded, 2) - 1)),
       opacity   calc(var(--duration) * .5)  ease-out                   calc(var(--delay) * var(--expanded, 0)),
@@ -16,9 +16,9 @@
     overflow: hidden;
     opacity: var(--expanded, 0);
     transform: var(--expanded, translateX(-40px)); // Slide from left
-  }
+  // }
 
-  &.expanded, &.expanding {
+  &--expanded, &--expanding {
     --expanded: 1;
   }
 }

--- a/src/components/Collapsible/Collapsible.test.js
+++ b/src/components/Collapsible/Collapsible.test.js
@@ -2,24 +2,24 @@ import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 import {act} from 'react-dom/test-utils';
-import Collapsible from './Collapsible';
+import Collapsible, {NAMESPACE} from './Collapsible';
 
 describe('<Collapsible/>', () => {
     describe('HTML Structure', () => {
         it('should render empty Collapsible if no children supplied', () => {
             const wrapper = mount(<Collapsible></Collapsible>);
-            expect(wrapper.find('.collapsible').children()).toHaveLength(0)
+            expect(wrapper.find(`.${NAMESPACE}`).children()).toHaveLength(0)
             wrapper.unmount();
         });
 
         it('should render a collapsed Collapsible', () => {
             const wrapper = mount(<Collapsible>foo</Collapsible>);
-            expect(wrapper.find('.collapsible')).toHaveLength(1);
+            expect(wrapper.find(`.${NAMESPACE}`)).toHaveLength(1);
             wrapper.unmount();
         });
         it('should render an expanded Collapsible', () => {
             const wrapper = mount(<Collapsible expanded>foo</Collapsible>);
-            expect(wrapper.find('.collapsible.expanded')).toHaveLength(1);
+            expect(wrapper.find(`.${NAMESPACE}--expanded`)).toHaveLength(1);
             wrapper.unmount();
         });
     });
@@ -27,7 +27,7 @@ describe('<Collapsible/>', () => {
     describe('Props', () => {
         it('should support custom class name', () => {
             const wrapper = mount(<Collapsible className='bar'>foo</Collapsible>);
-            expect(wrapper.find('.collapsible.bar')).toHaveLength(1);
+            expect(wrapper.find(`.${NAMESPACE}.bar`)).toHaveLength(1);
             wrapper.unmount();
         });
     });
@@ -38,40 +38,40 @@ describe('<Collapsible/>', () => {
                 const onTransitionEnd = sinon.spy();
                 const wrapper = mount(<Collapsible onTransitionEnd={onTransitionEnd}><div/></Collapsible>);
 
-                wrapper.find('.content-wrapper').prop('onTransitionEnd')({propertyName: 'transform'});
+                wrapper.find(`.${NAMESPACE}`).prop('onTransitionEnd')({propertyName: 'transform'});
                 expect(onTransitionEnd.callCount).toEqual(1);
 
-                wrapper.find('.content-wrapper').prop('onTransitionEnd')({propertyName: 'width'});
+                wrapper.find(`.${NAMESPACE}`).prop('onTransitionEnd')({propertyName: 'width'});
                 expect(onTransitionEnd.callCount).toEqual(1);
                 wrapper.unmount();
             });
         });
         it('should toggle from collapsed to expanded', async () => {
             const wrapper = mount(<Collapsible>foo</Collapsible>);
-            expect(wrapper.find('.collapsible.expanded')).toHaveLength(0);
+            expect(wrapper.find(`.${NAMESPACE}--expanded`)).toHaveLength(0);
 
             wrapper.setProps({expanded: true});
             wrapper.update();
-            expect(wrapper.find('.collapsible.expanded')).toHaveLength(0); // should not have the "expanded" until transition is done
-            expect(wrapper.find('.collapsible.expanding')).toHaveLength(1);
+            expect(wrapper.find(`.${NAMESPACE}--expanded`)).toHaveLength(0); // should not have the "expanded" until transition is done
+            expect(wrapper.find(`.${NAMESPACE}--expanding`)).toHaveLength(1);
 
-            wrapper.find('.content-wrapper').simulate('transitionEnd', {propertyName: 'transform'});
+            wrapper.find(`.${NAMESPACE}`).simulate('transitionEnd', {propertyName: 'transform'});
 
-            expect(wrapper.find('.collapsible.expanding')).toHaveLength(0); // expading class should be removed once transition is done
+            expect(wrapper.find(`.${NAMESPACE}--expanding`)).toHaveLength(0); // expading class should be removed once transition is done
             wrapper.unmount();
         });
         it('should toggle from expanded to collapsed', async () => {
             const wrapper = mount(<Collapsible expanded>foo</Collapsible>);
-            expect(wrapper.find('.collapsible.expanded')).toHaveLength(1);
+            expect(wrapper.find(`.${NAMESPACE}--expanded`)).toHaveLength(1);
 
             wrapper.setProps({expanded: false});
             wrapper.update();
-            expect(wrapper.find('.collapsible.collapsing')).toHaveLength(1);
+            expect(wrapper.find(`.${NAMESPACE}--collapsing`)).toHaveLength(1);
 
-            wrapper.find('.content-wrapper').simulate('transitionEnd', {propertyName: 'transform'});
+            wrapper.find(`.${NAMESPACE}`).simulate('transitionEnd', {propertyName: 'transform'});
 
-            expect(wrapper.find('.collapsible.collapsing')).toHaveLength(0);
-            expect(wrapper.find('.collapsible').exists()).toBe.true;
+            expect(wrapper.find(`.${NAMESPACE}--collapsing`)).toHaveLength(0);
+            expect(wrapper.find(`.${NAMESPACE}`).exists()).toBe.true;
             wrapper.unmount();
         });
     });


### PR DESCRIPTION
- Added _namespace_ constant for dynamic selectors names
- Refactored selectors and changed to BEM naming, for improved isolation
- Tests now using the (exported) namespace
- TBD: use dynamic prefix imported from a centralized place

----
All examples have been tested manually.