### PR TITLE
Scrollable - Improved change detection

### DIFF
--- a/src/components/Scrollable/Scrollable.jsx
+++ b/src/components/Scrollable/Scrollable.jsx
@@ -115,7 +115,9 @@ export default class Scrollable extends React.PureComponent {
 
         const nextEvent = this.event.next,
             prevEvent = this.event.prev,
-            changed = nextEvent.scrollHeight !== prevEvent.scrollHeight ||
+            changed = nextEvent.clientHeight !== prevEvent.clientHeight ||
+                      nextEvent.scrollHeight !== prevEvent.scrollHeight ||
+                      nextEvent.clientWidth !== prevEvent.clientWidth ||
                       nextEvent.scrollWidth !== prevEvent.scrollWidth ||
                       nextEvent.top !== prevEvent.top ||
                       nextEvent.left !== prevEvent.left;


### PR DESCRIPTION
`clientWidth` & `clientHeight` should be taken into consideration when checking for changes in `updateScrollbars`.

This PR is a result of a bug I've seen in some situations, when the `clientHeight` changed in an editable (multiline) text box, when content is added/removed, and the scrollbar appears when it shouldn't have.