### PR TITLE
`useClickOutside` - added `options` argument to the hook

### DIFF
--- a/src/hooks/useClickOutside/useClickOutside.js
+++ b/src/hooks/useClickOutside/useClickOutside.js
@@ -33,25 +33,29 @@ import OverrideContext from './useClickOutside.context';
  * So once a click is detected in the component tree of the target component, we set a flag, which the
  * document event handler is checking against. When set to true, the click is considered to be "inside"
  * and so it is ignored.
- * 
+ *
  * This solution is further improved by separating the "click" event into "mousedown" and "mouseup",
- * allowing us to cover cases where the mouse is clicked inside the element, but released outside the 
+ * allowing us to cover cases where the mouse is clicked inside the element, but released outside the
  * element (for example, when dragging). In such cases the click is still considered as an inside click,
  * since it originated inside the element.
  *
  * @param {Function} callback
  */
-export const useClickOutside = callback => {
+export const useClickOutside = (callback, options) => {
+    const {target = _document, condition} = (options || {});
     const isClickedInside = useRef(false);
-    const isClickedOutside = useContext(OverrideContext);
+    let isClickedOutside = useContext(OverrideContext);
+
+    if (condition)
+        isClickedOutside = condition;
 
     useEventListener('mousedown', e => {
         isClickedInside.current = !isClickedOutside(isClickedInside.current, e)
-    }, {current: _document});
+    }, {current: target});
 
     useEventListener('mouseup', e => {
         isClickedInside.current ? isClickedInside.current = false : callback(e)
-    }, {current: _document});
+    }, {current: target});
 
     return useCallback(() => {
         isClickedInside.current = true;

--- a/src/hooks/useClickOutside/useClickOutside.test.js
+++ b/src/hooks/useClickOutside/useClickOutside.test.js
@@ -6,8 +6,8 @@ import {mount, shallow} from 'enzyme';
 import OverrideContext from './useClickOutside.context';
 import {useClickOutside, ClickOutside, ClickOutsideOverride} from './useClickOutside';
 
-const Elem = callback => {
-    useClickOutside(callback);
+const Elem = ({callback, options = {}}) => {
+    useClickOutside(callback, options);
     return <div/>;
 };
 
@@ -15,15 +15,37 @@ describe('useClickOutside()', () => {
     it('Should add an event listener to the document', () => {
         document.addEventListener = sinon.spy();
         document.removeEventListener = sinon.spy();
+
         let elem;
+
         act(() => {elem = mount(<Elem/>)});
         expect(document.addEventListener.callCount).toEqual(4); // 2 calls are done regardless, not sure why, but it only happens during testing
         expect(document.addEventListener.calledWith('mousedown')).toEqual(true);
         expect(document.addEventListener.calledWith('mouseup')).toEqual(true);
+
         act(() => {elem.unmount()});
         expect(document.removeEventListener.calledTwice).toEqual(true);
         expect(document.removeEventListener.calledWith('mousedown')).toEqual(true);
         expect(document.removeEventListener.calledWith('mouseup')).toEqual(true);
+    });
+
+    it('Should add an event listener a custom target', () => {
+        const target = {};
+
+        target.addEventListener = sinon.spy();
+        target.removeEventListener = sinon.spy();
+
+        let elem;
+
+        act(() => {elem = mount(<Elem options={{target}}/>)});
+        expect(target.addEventListener.callCount).toEqual(2);
+        expect(target.addEventListener.calledWith('mousedown')).toEqual(true);
+        expect(target.addEventListener.calledWith('mouseup')).toEqual(true);
+
+        act(() => {elem.unmount()});
+        expect(target.removeEventListener.calledTwice).toEqual(true);
+        expect(target.removeEventListener.calledWith('mousedown')).toEqual(true);
+        expect(target.removeEventListener.calledWith('mouseup')).toEqual(true);
     });
 
     it('Should not trigger the callback on click inside', () => {


### PR DESCRIPTION
```js
const useClickOutside = (callback, options)
```

## Added `options` optional argument (*Object*) to `useClickOutside`:

### `target`
control over `mousedown`/`mouseup` event handlers target (beside the `document`).

For example, in `React` the whole app resides with a wrapper element and not directly `<body>` 
so the `target` options could be set to something like `document.querySelector('#root')` and
so, if any "portaled" element (on the `body`) would not be considered as a "click outside".

### `condition`
Before this change, the only way to bypass the `isClickedOutside` condition (defined within the context) was to wrap the component with `<ClickOutsideOverride>` and pass a `condition` prop.

If a functional component is using the `useClickOutside` hook, it is easier to pass an argument than to wrap the JSX with a context provider (`ClickOutsideOverride`).