### PR TITLE
scrollable tracks should not inherit css from ancestors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,30 +44,33 @@
     "indent": ["error", 4],
     "quotes": ["error", "single", { "avoidEscape": true }],
     "jsx-quotes": ["error", "prefer-single"],
-    "prefer-const": ["error"],
-    "notice/notice": ["error", {"templateFile":"notice.js"}]
+    "prefer-const": ["error"]
   },
-  "overrides": [{
-    "files": ["*.jsx"],
-    "rules": {
-      "max-lines-per-function": ["error", { "max": 40, "skipComments": true, "skipBlankLines": true }]
+  "overrides": [
+    {
+      "files": ["./src/**/*.js", "./src/**/*.jsx"],
+      "rules": {
+        "notice/notice": ["error", {"templateFile":"notice.js"}]
+      }
+    },
+    {
+      "files": ["*.jsx"],
+      "rules": {
+        "max-lines-per-function": ["error", { "max": 40, "skipComments": true, "skipBlankLines": true }]
+      }
+    },
+    {
+      "files": ["*.test.js"],
+      "rules": {
+        "max-lines": 0,
+        "max-lines-per-function": 0,
+        "react/display-name": 0,
+        "no-nested-ternary": 0,
+        "complexity": 0,
+        "react/prop-types": 0,
+        "react/jsx-key": 0,
+        "notice/notice": 0
+      }
     }
-  },{
-    "files": ["index.js"],
-    "rules": {
-      "notice/notice": 0
-    }
-  },{
-    "files": ["*.test.js"],
-    "rules": {
-      "max-lines": 0,
-      "max-lines-per-function": 0,
-      "react/display-name": 0,
-      "no-nested-ternary": 0,
-      "complexity": 0,
-      "react/prop-types": 0,
-      "react/jsx-key": 0,
-      "notice/notice": 0
-    }
-  }]
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,33 +44,30 @@
     "indent": ["error", 4],
     "quotes": ["error", "single", { "avoidEscape": true }],
     "jsx-quotes": ["error", "prefer-single"],
-    "prefer-const": ["error"]
+    "prefer-const": ["error"],
+    "notice/notice": ["error", {"templateFile":"notice.js"}]
   },
-  "overrides": [
-    {
-      "files": ["./src/**/*.js", "./src/**/*.jsx"],
-      "rules": {
-        "notice/notice": ["error", {"templateFile":"notice.js"}]
-      }
-    },
-    {
-      "files": ["*.jsx"],
-      "rules": {
-        "max-lines-per-function": ["error", { "max": 40, "skipComments": true, "skipBlankLines": true }]
-      }
-    },
-    {
-      "files": ["*.test.js"],
-      "rules": {
-        "max-lines": 0,
-        "max-lines-per-function": 0,
-        "react/display-name": 0,
-        "no-nested-ternary": 0,
-        "complexity": 0,
-        "react/prop-types": 0,
-        "react/jsx-key": 0,
-        "notice/notice": 0
-      }
+  "overrides": [{
+    "files": ["*.jsx"],
+    "rules": {
+      "max-lines-per-function": ["error", { "max": 40, "skipComments": true, "skipBlankLines": true }]
     }
-  ]
+  },{
+    "files": ["index.js"],
+    "rules": {
+      "notice/notice": 0
+    }
+  },{
+    "files": ["*.test.js"],
+    "rules": {
+      "max-lines": 0,
+      "max-lines-per-function": 0,
+      "react/display-name": 0,
+      "no-nested-ternary": 0,
+      "complexity": 0,
+      "react/prop-types": 0,
+      "react/jsx-key": 0,
+      "notice/notice": 0
+    }
+  }]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,20 +1,18 @@
-module.exports = async () => {
-    return {
-        testEnvironment: 'jsdom',
-        verbose: true,
-        coverageReporters: ['lcov', 'text-summary', 'html'],
-        collectCoverageFrom: ['src/**/*.{js,jsx}', '!**/index.js', '!**/*.props.js', '!**/*.context.js', '!src/utility/mocks/mocks.js'],
-        coverageThreshold: {
-            global: {
-                'branches': 90,
-                'functions': 90,
-                'lines': 90,
-                'statements': 90,
-            },
+module.exports = async () => ({
+    testEnvironment: 'jsdom',
+    verbose: true,
+    coverageReporters: ['lcov', 'text-summary', 'html'],
+    collectCoverageFrom: ['src/**/*.{js,jsx}', '!**/index.js', '!**/*.props.js', '!**/*.context.js', '!src/utility/mocks/mocks.js'],
+    coverageThreshold: {
+        global: {
+            'branches': 90,
+            'functions': 90,
+            'lines': 90,
+            'statements': 90,
         },
-        setupFilesAfterEnv: ['<rootDir>/test/setup.js'],
-        moduleNameMapper: {
-            '.(css)$': '<rootDir>/test/mocks/styleMock.js',
-        },
-    };
-};
+    },
+    setupFilesAfterEnv: ['<rootDir>/test/setup.js'],
+    moduleNameMapper: {
+        '.(css)$': '<rootDir>/test/mocks/styleMock.js',
+    },
+});

--- a/src/components/Scrollable/components/_tracks.scss
+++ b/src/components/Scrollable/components/_tracks.scss
@@ -1,11 +1,11 @@
 @mixin tracks($isVertical) {
   .scrollbar {
-    &.#{if($isVertical, "vertically", "horizontally")}-scrollable .#{if($isVertical, "vertical", "horizontal")}-scrollbar-track {
+    &.#{if($isVertical, "vertically", "horizontally")}-scrollable > .#{if($isVertical, "vertical", "horizontal")}-scrollbar-track {
       visibility: visible;
       pointer-events: auto;
     }
 
-    .#{if($isVertical, "vertical", "horizontal")}-scrollbar-track {
+    > .#{if($isVertical, "vertical", "horizontal")}-scrollbar-track {
       position: absolute;
 
       #{if($isVertical, width, height)}: var(--scrollable-track-thickness, 12px);


### PR DESCRIPTION
it could be that multiple `Scrollable` components are nested, and so, their CSS styles affect each other because of how the tracks selectors are structured:

```css
.scrollbar.vertically-scrollable .vertical-scrollbar-track
```

which means nested components with the class `.vertical-scrollbar-track` will be affected.

This fix assumes the tracks are always direct children of a `.scrollbar` parent

see `src/components/Scrollable/components/_tracks.scss`